### PR TITLE
Update bot API to support version numbers.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -7,7 +7,7 @@
 //     \________/    ______                                   ______ 
 //                  |______|                                 |______|
 //
-// botAPI v2.4b2
+// botAPI v2.5b0
 
 
 var bots = [];
@@ -22,10 +22,11 @@ var messageStatus = {
   get split() {return ""}
 };
 
-function Bot(bot_name, header_character) {
+function Bot(bot_name, header_character, version) {
   this.name = bot_name;
   this.headerChar = header_character;
   this._basicCommands = [];
+  this.version = version || "v1";
   this.isRegistered = false;
   this.executeCommand = function (data) {
     return null;


### PR DESCRIPTION
This updates your version of the bot API so that it supports built-in version numbers. This will not break the functionality of your bot, outerBot, but I do recommend changing it over to the new system.

You would use `var outerBot = new Bot("outerBot","|","v1")` where you create the bot, and `outerBot.version` instead of recalling the constant.